### PR TITLE
Miscellaneous output changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,17 @@ dependencies = [
  "clap",
  "paste",
  "rgbds-obj",
+ "sigpipe",
  "termcolor",
+]
+
+[[package]]
+name = "sigpipe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5584bfb3e0d348139d8210285e39f6d2f8a1902ac06de343e06357d1d763d8e6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities", "development-tools::debugging", "game-de
 atty = "0.2.14"
 paste = "1.0"
 rgbds-obj = "0.1.1"
+sigpipe = "0.1.3"
 termcolor = "1.1.2"
 
 [dependencies.clap]

--- a/rgbobj.1
+++ b/rgbobj.1
@@ -150,6 +150,8 @@ directive containing the relevant requested info.
 Keyword list of what to display about symbols.
 The following keywords are accepted:
 .Bl -tag -width Ds -compact
+.It Cm id
+The symbol's ID number within the object file, as used in RPN expressions.
 .It Cm name
 The symbol's name, decoded as UTF-8.
 .It Cm section

--- a/rgbobj.1
+++ b/rgbobj.1
@@ -170,9 +170,11 @@ Trailing commas are not allowed (though this is subject to change in the future)
 A keyword can be prefixed with a dash
 .Ql -
 to negate it; note that whitespace is not permitted between the dash and the keyword, and that the first keyword in a list may not be negated.
-The special keyword
+The special keywords
 .Ql all
-is also accepted, enabling (or disabling, if negated) all keywords, unless specified otherwise.
+and
+.Ql none
+are also accepted, enabling or disabling all keywords (or vice-versa if negated), unless specified otherwise.
 .Pp
 Keyword lists can be omitted, in which case they default to their "min" value, as specified in their respective description.
 If the option is omitted entirely, however, nothing will be selected, and thus, nothing will be printed.

--- a/src/args.rs
+++ b/src/args.rs
@@ -232,7 +232,7 @@ pub mod features {
     // Implementations
 
     features!(HeaderFeatures: +size, counts);
-    features!(SymbolFeatures: +name, type, src, section, value);
+    features!(SymbolFeatures: +name, type, src, section, value, id);
     features!(SectionFeatures: +name, size, type, org, bank, align, data);
     features!(PatchFeatures: +count, src, offset, pcsection, pcoffset, type, rpn, data);
     features!(AssertionFeatures: +src, +offset, section, pcoffset, type, rpn, -data, +message);

--- a/src/args.rs
+++ b/src/args.rs
@@ -26,7 +26,7 @@ pub mod features {
         /// Create a new, empty, set of features.
         fn new() -> Self;
 
-        /// Enable or disable all features at once; used by the pseudo-keyword `all`.
+        /// Enable or disable all features at once; used by the pseudo-keywords `all` and `none`.
         ///
         /// Exception: features prefixed with a `-` are *not* enabled by this.
         fn set_all(&mut self, enable: bool);
@@ -87,6 +87,8 @@ pub mod features {
 
                 if keyword == "all" {
                     features.set_all(enable);
+                } else if keyword == "none" {
+                    features.set_all(!enable);
                 } else {
                     // See which keyword this matches; if none, report the error
                     let which = F::KEYWORDS
@@ -95,7 +97,7 @@ pub mod features {
                         .find(|(_, &candidate)| keyword == candidate)
                         .ok_or_else(|| {
                             let mut msg =
-                                format!("Unknown keyword \"{}\", expected one of: all", keyword);
+                                format!("Unknown keyword \"{}\", expected one of: all, none", keyword);
                             for keyword in F::KEYWORDS {
                                 msg.push_str(", ");
                                 msg.push_str(keyword);
@@ -283,7 +285,7 @@ impl ValueEnum for RpnPrintType {
 fn get_cmd() -> Command<'static> {
     command!()
         .about("Prints out RGBDS object files in a human-friendly manner")
-        .after_help("A keyword list is a comma-separated list of keywords, with whitespace ignored around keywords.\nA keyword can be prefixed with a dash '-', negating its effect; note that whitespace is not permitted between the dash and the keyword, and that the first keyword may not be negated.\nKeyword lists can be omitted, in which case they default to the \"min\" value.\n\nSee `man 1 rgbobj` for more information, including what each keyword does.")
+        .after_help("A keyword list is a comma-separated list of keywords.\nA keyword can be prefixed with a dash '-', negating its effect.\nThe special keywords 'all' and 'none' enable or disable all keywords unless specified otherwise.\n\nSee `man 1 rgbobj` for more information, including what each keyword does.")
         .arg(arg!(-A --all "Display \"all\" output for all output types; this overrides other display options"))
         .arg(arg!(--color <enable> "Whether to color output").value_parser(value_parser!(Colorization)).default_value("auto").required(false))
         .arg(arg!(-r --rpn <format> "The format to use for printing RPN").value_parser(value_parser!(RpnPrintType)).default_value("RPN").required(false))

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,6 +35,8 @@ pub mod features {
 
         /// Is any feature enabled?
         fn any(&self) -> bool;
+        /// Is any feature enabled besides the given one?
+        fn any_besides(&self, which: usize) -> bool;
         /// Is a given feature enabled?
         fn get(&self, which: usize) -> bool;
     }
@@ -206,6 +208,10 @@ pub mod features {
 
                 fn any(&self) -> bool {
                     self.0 != 0
+                }
+
+                fn any_besides(&self, which: usize) -> bool {
+                    self.0 & !(1 << which) != 0
                 }
 
                 fn get(&self, which: usize) -> bool {

--- a/src/args.rs
+++ b/src/args.rs
@@ -161,7 +161,7 @@ pub mod features {
     ///
     /// Syntax: (name: feature1, feature2, +feature3, -feature4, ...)
     ///
-    /// Each feature must be an identifier (keywords can be "escaped": `r#type`).
+    /// Each feature must be an identifier or a keyword.
     /// Prefixing a feature with a `+` makes it enabled by default, whereas prefixing it with `-` prevents the pseudo-feature `all` from enabling it.
     macro_rules! features {
         ($name:ident: $($args:tt)*) => {
@@ -222,10 +222,10 @@ pub mod features {
     // Implementations
 
     features!(HeaderFeatures: +size, counts);
-    features!(SymbolFeatures: +name, r#type, src, section, value);
-    features!(SectionFeatures: +name, size, r#type, org, bank, align, data);
-    features!(PatchFeatures: +count, src, offset, pcsection, pcoffset, r#type, rpn, data);
-    features!(AssertionFeatures: +src, +offset, section, pcoffset, r#type, rpn, -data, +message);
+    features!(SymbolFeatures: +name, type, src, section, value);
+    features!(SectionFeatures: +name, size, type, org, bank, align, data);
+    features!(PatchFeatures: +count, src, offset, pcsection, pcoffset, type, rpn, data);
+    features!(AssertionFeatures: +src, +offset, section, pcoffset, type, rpn, -data, +message);
 }
 use features::*;
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -96,8 +96,10 @@ pub mod features {
                         .enumerate()
                         .find(|(_, &candidate)| keyword == candidate)
                         .ok_or_else(|| {
-                            let mut msg =
-                                format!("Unknown keyword \"{}\", expected one of: all, none", keyword);
+                            let mut msg = format!(
+                                "Unknown keyword \"{}\", expected one of: all, none",
+                                keyword
+                            );
                             for keyword in F::KEYWORDS {
                                 msg.push_str(", ");
                                 msg.push_str(keyword);

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,7 @@ fn work(args: &Args) -> Result<(), MainError> {
 
         let mut separate_lines = false;
 
-        let mut symbol_id = 0;
-        for symbol in object.symbols() {
+        for (symbol_id, symbol) in object.symbols().iter().enumerate() {
             if separate_lines {
                 println!();
             }
@@ -294,8 +293,6 @@ fn work(args: &Args) -> Result<(), MainError> {
             if printed_lines > 1 {
                 separate_lines = true;
             }
-
-            symbol_id += 1;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,13 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.symbol.any() && !object.symbols().is_empty() {
         print_header!("Symbols");
 
+        let mut printed_first = false;
+
         for symbol in object.symbols() {
+            if printed_first {
+                println!();
+            }
+
             let mut printed_lines = 0;
 
             if args.symbol.get(SymbolFeatures::NAME) {
@@ -237,7 +243,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                println!();
+                printed_first = true;
             }
         }
     }
@@ -247,7 +253,13 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.section.any() && !object.sections().is_empty() {
         print_header!("Sections");
 
+        let mut printed_first = false;
+
         for section in object.sections().iter() {
+            if printed_first {
+                println!();
+            }
+
             let mut printed_lines = 0;
             let mut first_line_empty = true;
 
@@ -585,7 +597,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                println!();
+                printed_first = true;
             }
         }
     }
@@ -595,7 +607,13 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.assertion.any() && !object.assertions().is_empty() {
         print_header!("Assertions");
 
+        let mut printed_first = false;
+
         for assertion in object.assertions() {
+            if printed_first {
+                println!();
+            }
+
             let mut printed_lines = 0;
             let mut first_line_empty = true;
 
@@ -721,7 +739,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                println!();
+                printed_first = true;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ use args::features::*;
 use args::{Args, RpnPrintType};
 
 fn main() {
+    // Don't panic when printing to a closed pipe, e.g. with `rgbobj | head`.
+    sigpipe::reset();
+
     let args = args::parse();
 
     if let Err(err) = work(&args) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,14 +158,24 @@ fn work(args: &Args) -> Result<(), MainError> {
         }};
     }
 
-    macro_rules! print_bytes {
-        ($bytes:expr) => {
-            print!("[{:02x}", ($bytes).bytes()[0]);
-            // TODO: wrap the RPN bytes nicely
-            for byte in &($bytes).bytes()[1..] {
-                print!(" {byte:02x}");
+    macro_rules! print_rpn_data {
+        ($indent:expr, $rpn:expr) => {
+            let len = ($rpn).bytes().len();
+            println!("{}RPN data ({len} byte{}):", $indent, plural!(len, "s"));
+
+            print!("{}    [{:02x}", $indent, ($rpn).bytes()[0]);
+            let mut i = 1;
+            for byte in &($rpn).bytes()[1..] {
+                if i % 16 == 0 {
+                    println!();
+                    print!("{}     ", $indent);
+                } else {
+                    print!(" ");
+                }
+                print!("{byte:02x}");
+                i += 1;
             }
-            print!("]");
+            println!("]");
         };
     }
 
@@ -570,14 +580,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                             }
 
                             if args.patch.get(PatchFeatures::DATA) {
-                                let len = patch.expr().bytes().len();
-                                println!(
-                                    "{indent}{patch_indent}RPN data ({len} byte{}):",
-                                    plural!(len, "s")
-                                );
-                                print!("{indent}{patch_indent}    ");
-                                print_bytes!(expr);
-                                println!();
+                                print_rpn_data!(format!("{indent}{patch_indent}"), expr);
                                 printed_lines += 2;
                             }
                         }
@@ -679,11 +682,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                 }
 
                 if args.assertion.get(AssertionFeatures::DATA) {
-                    let len = assertion.expr().bytes().len();
-                    println!("{indent}RPN data ({len} byte{}):", plural!(len, "s"));
-                    print!("{indent}    ");
-                    print_bytes!(expr);
-                    println!();
+                    print_rpn_data!(format!("{indent}"), expr);
                     printed_lines += 2;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn work(args: &Args) -> Result<(), MainError> {
         };
     }
 
-    macro_rules! header {
+    macro_rules! print_header {
         ($str:literal) => {
             println!();
             println!();
@@ -146,7 +146,7 @@ fn work(args: &Args) -> Result<(), MainError> {
     // Print symbols
 
     if args.symbol.any() && !object.symbols().is_empty() {
-        header!("Symbols");
+        print_header!("Symbols");
 
         for symbol in object.symbols() {
             println!();
@@ -235,7 +235,7 @@ fn work(args: &Args) -> Result<(), MainError> {
     // Print sections
 
     if args.section.any() && !object.sections().is_empty() {
-        header!("Sections");
+        print_header!("Sections");
 
         for section in object.sections().iter() {
             println!();
@@ -548,7 +548,7 @@ fn work(args: &Args) -> Result<(), MainError> {
     // Print assertions
 
     if args.assertion.any() && !object.assertions().is_empty() {
-        header!("Assertions");
+        print_header!("Assertions");
 
         for assertion in object.assertions() {
             println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,24 +153,38 @@ fn work(args: &Args) -> Result<(), MainError> {
 
         let mut separate_lines = false;
 
+        let mut symbol_id = 0;
         for symbol in object.symbols() {
             if separate_lines {
                 println!();
             }
 
             let mut printed_lines = 0;
+            let mut first_line_empty = true;
 
             if args.symbol.get(SymbolFeatures::NAME) {
                 print!("{}", String::from_utf8_lossy(symbol.name()));
-                if args.symbol.get(SymbolFeatures::TYPE) {
-                    print!(" "); // Pad between the symbol name and type
-                } else {
-                    println!();
-                    printed_lines += 1;
-                }
+                first_line_empty = false;
             }
+
+            if args.symbol.get(SymbolFeatures::ID) {
+                if !first_line_empty {
+                    print!(" ");
+                }
+                print!("(#{})", symbol_id);
+                first_line_empty = false;
+            }
+
             if args.symbol.get(SymbolFeatures::TYPE) {
-                println!("[{}]", symbol.visibility().name());
+                if !first_line_empty {
+                    print!(" ");
+                }
+                print!("[{}]", symbol.visibility().name());
+                first_line_empty = false;
+            }
+
+            if !first_line_empty {
+                println!();
                 printed_lines += 1;
             }
 
@@ -240,6 +254,8 @@ fn work(args: &Args) -> Result<(), MainError> {
             if printed_lines > 1 {
                 separate_lines = true;
             }
+
+            symbol_id += 1;
         }
     }
 
@@ -266,7 +282,6 @@ fn work(args: &Args) -> Result<(), MainError> {
                     }
                 }
                 print!(" \"{}\"", String::from_utf8_lossy(section.name()));
-
                 first_line_empty = false;
             }
 
@@ -281,7 +296,6 @@ fn work(args: &Args) -> Result<(), MainError> {
                     }
                 }
                 print!("{}", section.type_data().name());
-
                 first_line_empty = false;
             }
 
@@ -294,7 +308,6 @@ fn work(args: &Args) -> Result<(), MainError> {
                 } else if first_line_empty {
                     print!("Floating");
                 }
-
                 first_line_empty = false;
             }
 
@@ -307,7 +320,6 @@ fn work(args: &Args) -> Result<(), MainError> {
                 } else if first_line_empty {
                     print!("Floating");
                 }
-
                 first_line_empty = false;
             }
 
@@ -333,7 +345,6 @@ fn work(args: &Args) -> Result<(), MainError> {
                     } else {
                         print!("ALIGN[{align}, {ofs}]");
                     }
-
                     first_line_empty = false;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -723,9 +723,7 @@ impl Display for MainError {
     }
 }
 
-impl Error for MainError {
-    // add code here
-}
+impl Error for MainError {}
 
 impl From<io::Error> for MainError {
     fn from(err: io::Error) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,8 +114,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             println!();
             setup!(bold);
             println!($str);
-            // Print as many dashes as there are characters; this requires the literal to be at least as long
-            println!("{}", &"--------------"[..$str.len()]);
+            println!("{}", "-".repeat($str.len()));
             reset!();
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,12 +174,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                 printed_lines += 1;
             }
 
-            let indent =
-                if args.symbol.get(SymbolFeatures::NAME) || args.symbol.get(SymbolFeatures::TYPE) {
-                    "    "
-                } else {
-                    ""
-                };
+            let indent = if printed_lines == 0 { "" } else { "    " };
 
             if let Some(data) = symbol.visibility().data() {
                 if args.symbol.get(SymbolFeatures::SRC) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,6 +542,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                                 if patch_line_empty { indent } else { " " },
                                 patch.patch_type().name()
                             );
+                            patch_line_empty = false;
                         }
 
                         if !patch_line_empty {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             println!($str);
             println!("{}", "-".repeat($str.len()));
             reset!();
+            println!();
         };
     }
 
@@ -151,13 +152,10 @@ fn work(args: &Args) -> Result<(), MainError> {
         print_header!("Symbols");
 
         for symbol in object.symbols() {
-            println!();
-
             if args.symbol.get(SymbolFeatures::NAME) {
                 print!("{}", String::from_utf8_lossy(symbol.name()));
                 if args.symbol.get(SymbolFeatures::TYPE) {
-                    // Pad between the two
-                    print!(" ");
+                    print!(" "); // Pad between the two
                 } else {
                     println!();
                 }
@@ -166,11 +164,12 @@ fn work(args: &Args) -> Result<(), MainError> {
                 println!("[{}]", symbol.visibility().name());
             }
 
-            let indent = if args.symbol.get(SymbolFeatures::NAME) {
-                "    "
-            } else {
-                ""
-            };
+            let indent =
+                if args.symbol.get(SymbolFeatures::NAME) || args.symbol.get(SymbolFeatures::TYPE) {
+                    "    "
+                } else {
+                    ""
+                };
 
             if let Some(data) = symbol.visibility().data() {
                 if args.symbol.get(SymbolFeatures::SRC) {
@@ -219,18 +218,18 @@ fn work(args: &Args) -> Result<(), MainError> {
                     } else {
                         print!("Constant");
                     }
-
                     if args.symbol.get(SymbolFeatures::VALUE) {
-                        print!(" ");
+                        print!(" "); // Pad between the two
                     } else {
                         println!();
                     }
                 }
-
                 if args.symbol.get(SymbolFeatures::VALUE) {
                     println!("[@ ${:04x}]", data.value());
                 }
             }
+
+            println!();
         }
     }
 
@@ -240,8 +239,6 @@ fn work(args: &Args) -> Result<(), MainError> {
         print_header!("Sections");
 
         for section in object.sections().iter() {
-            println!();
-
             let mut line_empty = true; // Has anything been printed on this line?
 
             if args.section.get(SectionFeatures::NAME) {
@@ -548,6 +545,8 @@ fn work(args: &Args) -> Result<(), MainError> {
                     }
                 }
             }
+
+            println!();
         }
     }
 
@@ -557,7 +556,6 @@ fn work(args: &Args) -> Result<(), MainError> {
         print_header!("Assertions");
 
         for assertion in object.assertions() {
-            println!();
             let mut line_empty = true;
 
             if args.assertion.get(AssertionFeatures::SRC) {
@@ -676,6 +674,8 @@ fn work(args: &Args) -> Result<(), MainError> {
                     println!("{indent}Message: \"{}\"", String::from_utf8_lossy(msg));
                 }
             }
+
+            println!();
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,15 +135,12 @@ fn work(args: &Args) -> Result<(), MainError> {
         let len = file.get_ref().metadata().unwrap().len();
         print!(" [{len} byte{}]", plural!(len, "s"));
     }
-    println!(":  RGBDS object v9 revision {}", object.revision());
+    println!(": RGBDS object v9 revision {}", object.revision());
 
     if args.header.get(HeaderFeatures::COUNTS) {
-        println!(
-            "Symbols: {}    Sections: {}    Assertions: {}",
-            object.symbols().len(),
-            object.sections().len(),
-            object.assertions().len()
-        );
+        println!("    Symbols: {}", object.symbols().len());
+        println!("    Sections: {}", object.sections().len());
+        println!("    Assertions: {}", object.assertions().len());
     }
 
     // Print symbols

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,7 +416,11 @@ fn work(args: &Args) -> Result<(), MainError> {
                 if args.patch.any() {
                     if args.patch.get(PatchFeatures::COUNT) {
                         let len = data.patches().len();
-                        println!("{indent}{len} patch{}:", plural!(len, "es"));
+                        println!(
+                            "{indent}{len} patch{}{}",
+                            plural!(len, "es"),
+                            if len > 0 { ":" } else { "" }
+                        );
                     }
 
                     for patch in data.patches() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             if args.symbol.get(SymbolFeatures::NAME) {
                 print!("{}", String::from_utf8_lossy(symbol.name()));
                 if args.symbol.get(SymbolFeatures::TYPE) {
-                    print!(" "); // Pad between the two
+                    print!(" "); // Pad between the symbol name and type
                 } else {
                     println!();
                     printed_lines += 1;
@@ -224,7 +224,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                         print!("Constant");
                     }
                     if args.symbol.get(SymbolFeatures::VALUE) {
-                        print!(" "); // Pad between the two
+                        print!(" "); // Pad between the section name and value
                     } else {
                         println!();
                         printed_lines += 1;
@@ -336,15 +336,19 @@ fn work(args: &Args) -> Result<(), MainError> {
                 printed_lines += 1;
             }
 
-            let indent = if first_line_empty {
-                ""
-            } else {
-                "    "
-            };
+            let indent = if first_line_empty { "" } else { "    " };
 
             if args.section.get(SectionFeatures::SIZE) {
                 let len = section.size();
-                println!("{indent}${len:04x} ({len}) byte{}", plural!(len, "s"));
+                println!(
+                    "{indent}${len:04x} ({len}) byte{}{}",
+                    plural!(len, "s"),
+                    if len > 0 && args.section.get(SectionFeatures::DATA) {
+                        ":"
+                    } else {
+                        ""
+                    }
+                );
                 printed_lines += 1;
             }
 
@@ -431,13 +435,25 @@ fn work(args: &Args) -> Result<(), MainError> {
                     }
                 }
 
+                if args.section.get(SectionFeatures::DATA)
+                    && !data.data().is_empty()
+                    && args.patch.any()
+                {
+                    println!(); // Pad between the section data and patches
+                    printed_lines += 1;
+                }
+
                 if args.patch.any() {
                     if args.patch.get(PatchFeatures::COUNT) {
                         let len = data.patches().len();
                         println!(
                             "{indent}{len} patch{}{}",
                             plural!(len, "es"),
-                            if len > 0 { ":" } else { "" }
+                            if len > 0 && args.patch.any_besides(PatchFeatures::COUNT) {
+                                ":"
+                            } else {
+                                ""
+                            }
                         );
                         printed_lines += 1;
                     }
@@ -506,11 +522,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                             printed_lines += 1;
                         }
 
-                        let patch_indent = if patch_line_empty {
-                            ""
-                        } else {
-                            "    "
-                        };
+                        let patch_indent = if patch_line_empty { "" } else { "    " };
 
                         if args.patch.get(PatchFeatures::PCSECTION)
                             || args.patch.get(PatchFeatures::PCOFFSET)
@@ -642,11 +654,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                 printed_lines += 1;
             }
 
-            let indent = if first_line_empty {
-                ""
-            } else {
-                "    "
-            };
+            let indent = if first_line_empty { "" } else { "    " };
 
             if args.assertion.get(AssertionFeatures::SECTION)
                 || args.assertion.get(AssertionFeatures::PCOFFSET)

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,10 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.symbol.any() && !object.symbols().is_empty() {
         print_header!("Symbols");
 
-        let mut printed_first = false;
+        let mut separate_lines = false;
 
         for symbol in object.symbols() {
-            if printed_first {
+            if separate_lines {
                 println!();
             }
 
@@ -238,7 +238,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                printed_first = true;
+                separate_lines = true;
             }
         }
     }
@@ -248,10 +248,10 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.section.any() && !object.sections().is_empty() {
         print_header!("Sections");
 
-        let mut printed_first = false;
+        let mut separate_lines = false;
 
         for section in object.sections().iter() {
-            if printed_first {
+            if separate_lines {
                 println!();
             }
 
@@ -592,7 +592,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                printed_first = true;
+                separate_lines = true;
             }
         }
     }
@@ -602,10 +602,10 @@ fn work(args: &Args) -> Result<(), MainError> {
     if args.assertion.any() && !object.assertions().is_empty() {
         print_header!("Assertions");
 
-        let mut printed_first = false;
+        let mut separate_lines = false;
 
         for assertion in object.assertions() {
-            if printed_first {
+            if separate_lines {
                 println!();
             }
 
@@ -734,7 +734,7 @@ fn work(args: &Args) -> Result<(), MainError> {
             }
 
             if printed_lines > 1 {
-                printed_first = true;
+                separate_lines = true;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,14 +158,27 @@ fn work(args: &Args) -> Result<(), MainError> {
         }};
     }
 
+    macro_rules! print_rpn_expr {
+        ($indent:expr, $expr:expr) => {
+            println!("{}{} expression:", $indent, args.rpn);
+            print!("{}    ", $indent);
+            // TODO: wrap the RPN expression nicely
+            if matches!(args.rpn, RpnPrintType::Infix) {
+                println!("{:#}", $expr);
+            } else {
+                println!("{}", $expr);
+            }
+        };
+    }
+
     macro_rules! print_rpn_data {
-        ($indent:expr, $rpn:expr) => {
-            let len = ($rpn).bytes().len();
+        ($indent:expr, $data:expr) => {
+            let len = ($data).bytes().len();
             println!("{}RPN data ({len} byte{}):", $indent, plural!(len, "s"));
 
-            print!("{}    [{:02x}", $indent, ($rpn).bytes()[0]);
+            print!("{}    [{:02x}", $indent, ($data).bytes()[0]);
             let mut i = 1;
-            for byte in &($rpn).bytes()[1..] {
+            for byte in &($data).bytes()[1..] {
                 if i % 16 == 0 {
                     println!();
                     print!("{}     ", $indent);
@@ -570,15 +583,9 @@ fn work(args: &Args) -> Result<(), MainError> {
                             error!("Empty patch RPN expression");
                         } else {
                             if args.patch.get(PatchFeatures::RPN) {
-                                println!("{indent}{patch_indent}{} expression:", args.rpn);
-                                if matches!(args.rpn, RpnPrintType::Infix) {
-                                    println!("{indent}{patch_indent}    {expr:#}");
-                                } else {
-                                    println!("{indent}{patch_indent}    {expr}");
-                                }
+                                print_rpn_expr!(format!("{indent}{patch_indent}"), expr);
                                 printed_lines += 2;
                             }
-
                             if args.patch.get(PatchFeatures::DATA) {
                                 print_rpn_data!(format!("{indent}{patch_indent}"), expr);
                                 printed_lines += 2;
@@ -672,15 +679,9 @@ fn work(args: &Args) -> Result<(), MainError> {
                 error!("Empty assertion RPN expression");
             } else {
                 if args.assertion.get(AssertionFeatures::RPN) {
-                    println!("{indent}{} expression:", args.rpn);
-                    if matches!(args.rpn, RpnPrintType::Infix) {
-                        println!("{indent}    {expr:#}");
-                    } else {
-                        println!("{indent}    {expr}");
-                    }
+                    print_rpn_expr!(format!("{indent}"), expr);
                     printed_lines += 2;
                 }
-
                 if args.assertion.get(AssertionFeatures::DATA) {
                     print_rpn_data!(format!("{indent}"), expr);
                     printed_lines += 2;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ fn main() {
 
     if let Err(err) = work(&args) {
         let mut stderr = StandardStream::stderr(args.color_err);
-
         stderr
             .set_color(
                 ColorSpec::new()
@@ -152,8 +151,6 @@ fn work(args: &Args) -> Result<(), MainError> {
         for symbol in object.symbols() {
             println!();
 
-            let mut indent = "";
-
             if args.symbol.get(SymbolFeatures::NAME) {
                 print!("{}", String::from_utf8_lossy(symbol.name()));
                 if args.symbol.get(SymbolFeatures::TYPE) {
@@ -162,13 +159,16 @@ fn work(args: &Args) -> Result<(), MainError> {
                 } else {
                     println!();
                 }
-                indent = "    ";
             }
-
             if args.symbol.get(SymbolFeatures::TYPE) {
                 println!("[{}]", symbol.visibility().name());
-                indent = "    ";
             }
+
+            let indent = if args.symbol.get(SymbolFeatures::NAME) {
+                "    "
+            } else {
+                ""
+            };
 
             if let Some(data) = symbol.visibility().data() {
                 if args.symbol.get(SymbolFeatures::SRC) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,6 +639,7 @@ fn work(args: &Args) -> Result<(), MainError> {
                     if first_line_empty { "" } else { " " },
                     assertion.err_type().name()
                 );
+                first_line_empty = false;
             }
 
             if !first_line_empty {


### PR DESCRIPTION
As we discussed:

- Allow printing symbols' ID numbers, since they show up in RPN expressions
- Users can just pass "`type`", not "`r#type`"
- Support special "`none`" keyword to disable all output for a feature
- Print counts one per line
- Only print blank lines between multi-line items (symbols, sections, assertions)
- Print a blank line between section data and patches when both are printed
- Only print a colon after "patches" or "bytes" when specific data follows
- Wrap RPN data, 16 bytes per line

And also:

- Don't panic when printing to a closed pipe, e.g. with `rgbobj | head` (see [burntsushi's explanation](https://stackoverflow.com/questions/65755853/simple-word-count-rust-program-outputs-valid-stdout-but-panicks-when-piped-to-he/65760807#65760807))

This does not change assertions to print symbol names instead of "`Sym#1337`"; that's handled by the rgbds-obj package.