### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,10 +136,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "rgbds-obj"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b801be867c2f9f4cc495199b900023cb547be9f2c5814ad1864987e7cc418b56"
 
 [[package]]
 name = "rgbobj"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgbobj"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["ISSOtm <me@eldred.fr>"]
 edition = "2018"
 description = "A command-line program to print out RGBDS object files."

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,11 @@ fn work(args: &Args) -> Result<(), MainError> {
         let len = file.get_ref().metadata().unwrap().len();
         print!(" [{len} byte{}]", plural!(len, "s"));
     }
-    println!(": RGBDS object v9 revision {}", object.revision());
+    println!(
+        ": RGBDS object v{} revision {}",
+        object.version(),
+        object.revision()
+    );
 
     if args.header.get(HeaderFeatures::COUNTS) {
         println!("    Symbols: {}", object.symbols().len());


### PR DESCRIPTION
This needs to wait for rgbds-obj 0.2.0 to be tagged on GitHub and published on crates.io. Then the Cargo.lock will update properly.

After this merges, it should likewise be tagged as `v0.3.0` and published on crates.io.

Fixes #7