### PR TITLE
Fix printing the RGBDS object version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn work(args: &Args) -> Result<(), MainError> {
     }
     println!(
         ": RGBDS object v{} revision {}",
-        object.version(),
+        object.version() as char,
         object.revision()
     );
 


### PR DESCRIPTION
Fixes #10

Goes with https://github.com/gbdev/rgbds-obj/pull/8